### PR TITLE
Add encoding to CSV reader

### DIFF
--- a/dhelper.py
+++ b/dhelper.py
@@ -801,7 +801,7 @@ def mkFacStr(fcolors, *ccosts):
 def loadCards():
   fn = CFG['cards']['filename']
   cards = {}
-  with open(fn, 'r') as fp:
+  with open(fn, 'r', encoding='utf-8') as fp:
     csvr = csv.reader(fp)
     for row in csvr:
       if len(row) < 19 or row[0] == 'Reg':


### PR DESCRIPTION
I've got some problems with encoding while reading CSV files generated by program. Adding this line to CSV reader got rid of the problem and averything works now, I think it should be added by default.